### PR TITLE
Add filltered voltage warning switch

### DIFF
--- a/src/assets/tooltips.json
+++ b/src/assets/tooltips.json
@@ -241,7 +241,10 @@
     "text": "Set to the value received by your tx or in the OSD view with a full lipo"
   },
   "voltage.vbattlow": {
-    "text": "Set the desired voltage to trigger a warning, single cell voltage is used Default 3.3V (uses Fuel gauge volts)",
+    "text": "Set the desired voltage to trigger a warning, single cell voltage is used Default 3.3V (uses Fuel gauge volts by default)",
     "link": "https://docs.bosshobby.com/Features/#voltage"
+  },
+  "voltage.use_filtered_voltage_for_warnings": {
+    "text": "Use filtered voltage instead Fuel gauge volts for Warnings"
   }
 }

--- a/src/panel/Voltage.vue
+++ b/src/panel/Voltage.vue
@@ -166,6 +166,33 @@
             </div>
           </div>
         </div>
+
+        <div class="field is-horizontal">
+          <div class="field-label">
+            <label class="label">
+              Filtered voltage warnings
+              <tooltip entry="voltage.use_filtered_voltage_for_warnings" />
+            </label>
+          </div>
+          <div class="field-body">
+            <div class="field">
+              <div class="control is-expanded">
+                <input
+                  type="checkbox"
+                  class="switch"
+                  id="use_filtered_voltage_for_warnings"
+                  :checked="profile.voltage.use_filtered_voltage_for_warnings || 0"
+                  @change="profile.voltage.use_filtered_voltage_for_warnings = profile.voltage.use_filtered_voltage_for_warnings ? 0 : 1"
+                />
+                <label
+                  class="py-0"
+                  style="height: 2em"
+                  for="use_filtered_voltage_for_warnings"
+                ></label>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -140,6 +140,7 @@ export interface profile_voltage_t {
   vbattlow: number;
   actual_battery_voltage: number;
   reported_telemetry_voltage: number;
+  use_filtered_voltage_for_warnings: number;
   vbat_scale: number;
   ibat_scale: number;
 }


### PR DESCRIPTION
Add switch to voltage Section. This switch allows to use filtered voltage for warnings instead of fuel-gauge warnings


Related PR: https://github.com/BossHobby/QUICKSILVER/pull/116