### PR TITLE
Added LULU as filter option for filter selections

### DIFF
--- a/src/panel/FilterSettings.vue
+++ b/src/panel/FilterSettings.vue
@@ -302,6 +302,7 @@ export default defineComponent({
         { value: 1, text: "PT1" },
         { value: 2, text: "PT2" },
         { value: 3, text: "PT3" },
+        { value: 4, text: "LULU" },
       ],
       toggleOptions: [
         { value: 0, text: "Off" },


### PR DESCRIPTION
Hi!

One line change, just adding the LULU filter to the configurator.  The LULU filter works only as the first filter on either the gyro or dterm, if that needs changing, please let me know. It is still selectable in the second filters on the configurator but it gets thrown out.

Strong recommend keeping the filter only on the gyro and not on the dterm. :)

Kind regards,